### PR TITLE
chore(ci): remove reference to a non-existent file in the workflow

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -104,7 +104,6 @@ jobs:
           files: |
             CHANGELOG.md
             package.json
-            package-lock.json
             README.md
           tag: 'v${{ steps.create-release.outputs.new_version }}'
 


### PR DESCRIPTION
# Description

- Remove `package-lock.json` from the files list in the `draft-new-release` workflow.
- This file does not exist in the repo, causing the `github-signed-commit` step to fail, which prevents the release tag from being created 
