### PR TITLE
chore(ci): generate changelog after version bump in release workflow

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -85,14 +85,14 @@ jobs:
           HUSKY: 0
         run: |
           npm i -g conventional-changelog-cli
-          SUMMARY=$(((npx conventional-changelog -u) 2>&1) | sed "s/*/<br> */g" | sed "s/#/ /g" | tr -d '\n' || true)
-          echo $SUMMARY
           echo "Current version: $CURRENT_VERSION_VALUE"
           echo "New version: $NEW_VERSION_VALUE"
           npx replace $CURRENT_VERSION_VALUE $NEW_VERSION_VALUE README.md
           echo ${{ steps.create-release.outputs.new_version }}
-          echo "commit_summary=$SUMMARY" >> $GITHUB_OUTPUT
           npx standard-version --skip.commit --skip.tag
+          SUMMARY=$(((npx conventional-changelog -u) 2>&1) | sed "s/*/<br> */g" | sed "s/#/ /g" | tr -d '\n' || true)
+          echo $SUMMARY
+          echo "commit_summary=$SUMMARY" >> $GITHUB_OUTPUT
 
       - name: Create verified commit and tag via GitHub API
         uses: ryancyq/github-signed-commit@e9f3b28c80da7be66d24b8f501a5abe82a6b855f # v1.2.0

--- a/Rudder-Lotame.podspec
+++ b/Rudder-Lotame.podspec
@@ -14,10 +14,10 @@ Pod::Spec.new do |s|
   s.license          = { :type => "ELv2", :file => "LICENSE.md" }
   s.author           = { 'RudderStack' => 'arnab@rudderlabs.com' }
   s.source           = { :git => 'https://github.com/rudderlabs/rudder-integration-lotame-ios.git' , :tag => "v#{s.version}" }
-  s.platform         = :ios, "12.0"
+  s.platform         = :ios, "9.0"
   s.requires_arc = true
 
-  s.ios.deployment_target = '12.0'
+  s.ios.deployment_target = '8.0'
 
   s.source_files = 'Rudder-Lotame/Classes/**/*'
 

--- a/Rudder-Lotame.podspec
+++ b/Rudder-Lotame.podspec
@@ -14,10 +14,10 @@ Pod::Spec.new do |s|
   s.license          = { :type => "ELv2", :file => "LICENSE.md" }
   s.author           = { 'RudderStack' => 'arnab@rudderlabs.com' }
   s.source           = { :git => 'https://github.com/rudderlabs/rudder-integration-lotame-ios.git' , :tag => "v#{s.version}" }
-  s.platform         = :ios, "9.0"
+  s.platform         = :ios, "12.0"
   s.requires_arc = true
 
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '12.0'
 
   s.source_files = 'Rudder-Lotame/Classes/**/*'
 


### PR DESCRIPTION
# Description

- Move changelog summary generation to after the version bump so the PR description reflects the correct release version.
